### PR TITLE
feat: add initial project skeleton

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.hs]
+indent_style = space
+indent_size = 2
+
+[*.yaml]
+indent_style = space
+indent_size = 2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,42 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - id: setup
+        name: Setup GHC and Cabal
+        uses: haskell/actions/setup@v2
+        with:
+          ghc-version: "9.8.4"
+          cabal-version: "3.10.3.0"
+
+      - name: Cache cabal store
+        uses: actions/cache@v4
+        with:
+          path: ~/.cabal/store
+          key: cabal-${{ runner.os }}-${{ steps.setup.outputs.ghc-version }}-${{ hashFiles('cabal.project', 'hs-starter.cabal') }}
+          restore-keys: |
+            cabal-${{ runner.os }}-${{ steps.setup.outputs.ghc-version }}-
+            cabal-${{ runner.os }}-
+
+      - name: Update package index
+        run: cabal update
+
+      - name: Build
+        run: cabal build all
+
+      - name: Test
+        run: cabal test

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+# Cabal build artifacts
+dist/
+dist-*/
+dist-newstyle/
+
+# Cabal helper files
+cabal.project.local
+cabal.project.local~
+
+# Editor and tooling
+*.swp
+*.swo
+.idea/
+.vscode/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,22 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+Executable entry points live under `app/` (`Main.hs`, migration utilities) while reusable modules sit in `src/` by domain (e.g., `Starter/Database`). Database migrations belong in `db/pgroll/` with `.ledger` tracking order; anything generated (Squeal types, docs) should stay under `src/Starter/Database/Generated.hs`. Tests mirror runtime modules inside `test/`, grouping helpers under `Starter/Tests`.
+
+## Build, Test, and Development Commands
+Run `cabal build` for a full compile and `cabal test` to execute the tasty suite (property, unit, and Postgres smoke tests). Use `cabal run hs-starter` to launch the server skeleton and run `scripts/squealgen.sh` (which shells out to the upstream `squealgen` CLI) whenever migrations change. Start a Cabal repl with `cabal repl hs-starter` during development loops.
+
+## Coding Style & Naming Conventions
+Format Haskell with `ormolu` (`cabal run ormolu -- --mode inplace $(git ls-files '*.hs')`) before pushing. Stick to two-space indentation, GHC2021 extensions, and module prefixes of `Starter.<Area>`. Keep exported data types and constructors UpperCamelCase; local helpers may remain lowerCamelCase. Generated files must remain ASCII.
+
+## Database & Migrations Workflow
+Author schema changes in pgroll YAML first and append new files to `db/pgroll/.ledger`. After running migrations (see `scripts/squealgen.sh`), regenerate Haskell types with the upstream `squealgen` CLI. Never hand-edit `Starter.Database.Generated`; treat it as a build artifact.
+
+## Testing Guidelines
+`cabal test` runs tasty with falsify properties and tmp-postgres-backed smoke checks. Property suites live under `Starter.Tests.Property`; integration helpers use `Starter.Tests.Db`. When introducing new DB features, add tmp-postgres coverage or document why it is skipped. Target >85% coverage once the suite expands and note any regressions in PRs.
+
+## Commit & Pull Request Guidelines
+Follow `type: summary` messages (examples: `feat: add oauth login route`, `chore: regenerate squeal schema`). PRs should summarise migrations applied, commands run (`cabal build`, `scripts/squealgen.sh`), and include screenshots or curl output for API changes. Cross-link tracking issues and call out any follow-ups.
+
+## Environment & Tooling Notes
+Install pgroll, Docker, and the upstream `squealgen` CLI (see https://github.com/mwotton/squealgen) when working migrations; `scripts/squealgen.sh` expects all three plus a local Postgres image. Export sensitive settings via environment variables—not version control. GitHub Actions re-runs Cabal builds/tests with caching, so keep dependencies tidy and regenerate schema files before pushing.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Revision history for hs-starter
+
+## 0.1.0.0 -- YYYY-mm-dd
+
+* First version. Released on an unsuspecting world.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+# hs-starter
+
+Bootstrap Servant + Squeal application scaffolded with Cabal. Follow `AGENTS.md` for contributor guidance; roadmap and feature work are in progress.

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -1,0 +1,8 @@
+module Main (main) where
+
+import Starter.Prelude
+
+import Starter.Application (runApp)
+
+main :: IO ()
+main = runApp

--- a/app/Migrate.hs
+++ b/app/Migrate.hs
@@ -1,0 +1,4 @@
+module Main (main) where
+
+main :: IO ()
+main = putStrLn "Migration executable placeholder"

--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,12 @@
+packages: .
+
+tests: True
+
+write-ghc-environment-files: never
+
+allow-newer: records-sop:ghc-prim, records-sop:deepseq
+
+source-repository-package
+  type: git
+  location: https://github.com/jfischoff/tmp-postgres.git
+  tag: 7f2467a6d6d5f6db7eed59919a6773fe006cf22b

--- a/db/pgroll/.ledger
+++ b/db/pgroll/.ledger
@@ -1,0 +1,2 @@
+0001_bootstrap.yaml
+0002_add_users_and_logins.yaml

--- a/db/pgroll/0001_bootstrap.yaml
+++ b/db/pgroll/0001_bootstrap.yaml
@@ -1,0 +1,6 @@
+operations:
+  - sql:
+      up: |
+        -- Baseline placeholder migration. Add tables in subsequent revisions.
+      down: |
+        -- Baseline placeholder migration rollback.

--- a/db/pgroll/0002_add_users_and_logins.yaml
+++ b/db/pgroll/0002_add_users_and_logins.yaml
@@ -1,0 +1,69 @@
+operations:
+  - create_table:
+      name: users
+      columns:
+        - name: id
+          type: serial
+          pk: true
+        - name: provider
+          type: text
+        - name: subject
+          type: text
+        - name: email
+          type: text
+          nullable: true
+        - name: display_name
+          type: text
+          nullable: true
+        - name: avatar_url
+          type: text
+          nullable: true
+        - name: created_at
+          type: timestamptz
+          default: now()
+        - name: updated_at
+          type: timestamptz
+          default: now()
+  - create_constraint:
+      type: unique
+      table: users
+      name: users_provider_subject_key
+      columns:
+        - provider
+        - subject
+      up:
+        provider: provider
+        subject: subject
+      down:
+        provider: provider
+        subject: subject
+  - create_table:
+      name: oauth_login_events
+      columns:
+        - name: id
+          type: serial
+          pk: true
+        - name: user_id
+          type: integer
+        - name: provider
+          type: text
+        - name: raw_payload
+          type: jsonb
+        - name: logged_at
+          type: timestamptz
+          default: now()
+  - create_constraint:
+      type: foreign_key
+      table: oauth_login_events
+      name: oauth_login_events_user_id_fkey
+      columns:
+        - user_id
+      references:
+        table: users
+        columns:
+          - id
+        on_delete: CASCADE
+      up:
+        user_id: user_id
+      down:
+        user_id: user_id

--- a/hs-starter.cabal
+++ b/hs-starter.cabal
@@ -1,0 +1,72 @@
+cabal-version:      3.12
+name:               hs-starter
+version:            0.1.0.0
+synopsis:           Servant starter application with Squeal and testing scaffolding
+description:        Starter kit for LambdaLabs Haskell services built on Servant, Squeal, and modern tooling.
+license:            NONE
+author:             Mark Wotton
+maintainer:         mwotton@gmail.com
+build-type:         Simple
+extra-doc-files:    CHANGELOG.md AGENTS.md
+
+common common-settings
+    default-language: GHC2021
+    default-extensions:
+        NoImplicitPrelude,
+        OverloadedStrings,
+        DerivingStrategies,
+        DataKinds,
+        TypeOperators
+    ghc-options: -Wall -Wcompat -Wincomplete-uni-patterns -Wincomplete-record-updates
+    build-depends: base ^>=4.19.2.0
+
+library
+    import: common-settings
+    hs-source-dirs: src
+    exposed-modules:
+        Starter.Application
+        Starter.Database.Connection
+        Starter.Database.Schema
+        Starter.Prelude
+        Starter.Server
+    other-modules:
+        Starter.Database.Generated
+    build-depends:
+        aeson >=2.2 && <2.3,
+        bytestring >=0.11 && <0.13,
+        servant-server >=0.20 && <0.21,
+        squeal-postgresql >=0.9.2 && <0.10,
+        text >=2.0 && <2.2,
+        wai >=3.2 && <3.3,
+        warp >=3.4 && <3.5
+
+executable hs-starter
+    import: common-settings
+    hs-source-dirs: app
+    main-is:          Main.hs
+    build-depends:
+        hs-starter
+
+executable migrate
+    import: common-settings
+    hs-source-dirs: app
+    main-is:          Migrate.hs
+    build-depends:
+        hs-starter
+    buildable: False
+
+test-suite hs-starter-tests
+    import: common-settings
+    type:            exitcode-stdio-1.0
+    hs-source-dirs:  test
+    main-is:         Spec.hs
+    other-modules:
+        Starter.Tests.Db
+        Starter.Tests.Property
+    build-depends:
+        hs-starter,
+        falsify >=0.2 && <0.3,
+        squeal-postgresql >=0.9.2 && <0.10,
+        tasty ^>=1.5,
+        tasty-hunit ^>=0.10,
+        tmp-postgres

--- a/scripts/squealgen.sh
+++ b/scripts/squealgen.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+
+PG_IMAGE=${PG_IMAGE:-postgres:16-alpine}
+CONTAINER_NAME=${CONTAINER_NAME:-hs-starter-squealgen}
+DB_NAME=${DB_NAME:-hs_starter}
+DB_USER=${DB_USER:-postgres}
+DB_PASSWORD=${DB_PASSWORD:-postgres}
+if [[ -n "${HOST_PORT:-}" ]]; then
+  HOST_PORT_VALUE=$HOST_PORT
+elif command -v python3 >/dev/null 2>&1; then
+  HOST_PORT_VALUE=$(python3 - <<'PY'
+import socket
+with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+    s.bind(('', 0))
+    print(s.getsockname()[1])
+PY
+  )
+else
+  HOST_PORT_VALUE=65432
+fi
+
+HOST_PORT=$HOST_PORT_VALUE
+MIGRATIONS_DIR=${MIGRATIONS_DIR:-"$ROOT_DIR/db/pgroll"}
+OUTPUT_PATH=${OUTPUT_PATH:-"$ROOT_DIR/src/Starter/Database/Generated.hs"}
+
+cleanup() {
+  docker rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
+}
+
+trap cleanup EXIT
+
+for bin in pgroll docker squealgen; do
+  if ! command -v "$bin" >/dev/null 2>&1; then
+    case "$bin" in
+      squealgen)
+        cat >&2 <<'MSG'
+squealgen CLI not found. Install it from https://github.com/mwotton/squealgen (e.g. `make prefix=$HOME/.local install`).
+MSG
+        ;;
+      *)
+        echo "$bin binary not found on PATH" >&2
+        ;;
+    esac
+    exit 1
+  fi
+done
+
+cleanup
+
+docker run \
+  --rm \
+  --detach \
+  --name "$CONTAINER_NAME" \
+  -e POSTGRES_DB="$DB_NAME" \
+  -e POSTGRES_USER="$DB_USER" \
+  -e POSTGRES_PASSWORD="$DB_PASSWORD" \
+  -p "$HOST_PORT":5432 \
+  "$PG_IMAGE" >/dev/null
+
+echo "Waiting for PostgreSQL to accept connections..."
+until docker exec "$CONTAINER_NAME" pg_isready -U "$DB_USER" >/dev/null 2>&1; do
+  sleep 1
+  printf '.'
+ done
+printf '\n'
+
+PGROLL_SCHEMA=${PGROLL_SCHEMA:-public}
+PGROLL_STATE_SCHEMA=${PGROLL_PGROLL_SCHEMA:-pgroll}
+POSTGRES_URL="postgres://${DB_USER}:${DB_PASSWORD}@localhost:${HOST_PORT}/${DB_NAME}?sslmode=disable"
+
+echo "Initializing pgroll state..."
+pgroll init \
+  --postgres-url "$POSTGRES_URL" \
+  --schema "$PGROLL_SCHEMA" \
+  --pgroll-schema "$PGROLL_STATE_SCHEMA" || true
+
+echo "Applying migrations from $MIGRATIONS_DIR"
+pgroll migrate "$MIGRATIONS_DIR" \
+  --postgres-url "$POSTGRES_URL" \
+  --schema "$PGROLL_SCHEMA" \
+  --pgroll-schema "$PGROLL_STATE_SCHEMA" --complete
+
+echo "Generating Squeal schema to $OUTPUT_PATH"
+
+MODULE_NAME=${MODULE_NAME:-Starter.Database.Generated}
+SCHEMA=$PGROLL_SCHEMA
+IMPORTS=${SQUEALGEN_IMPORTS:-}
+
+mkdir -p "$(dirname "$OUTPUT_PATH")"
+
+PGHOST=localhost \
+PGPORT=$HOST_PORT \
+PGUSER=$DB_USER \
+PGPASSWORD=$DB_PASSWORD \
+  squealgen "$DB_NAME" "$MODULE_NAME" "$SCHEMA" "$IMPORTS" >"$OUTPUT_PATH.tmp"
+
+mv "$OUTPUT_PATH.tmp" "$OUTPUT_PATH"
+
+echo "Done"

--- a/src/Starter/Application.hs
+++ b/src/Starter/Application.hs
@@ -1,0 +1,18 @@
+module Starter.Application
+  ( runApp
+  , AppEnv (..)
+  ) where
+
+import Starter.Prelude
+
+import Network.Wai.Handler.Warp (run)
+import Starter.Server (app)
+
+data AppEnv = AppEnv
+  { appPort :: Int
+  }
+
+runApp :: IO ()
+runApp = do
+  let env = AppEnv {appPort = 8080}
+  run (appPort env) (app env)

--- a/src/Starter/Database/Connection.hs
+++ b/src/Starter/Database/Connection.hs
@@ -1,0 +1,99 @@
+module Starter.Database.Connection
+  ( DbConfig (..)
+  , defaultDbConfig
+  , loadDbConfigFromEnv
+  , renderConnectionString
+  , withAppConnection
+  ) where
+
+import Starter.Prelude
+
+import Data.ByteString (ByteString)
+import Data.Maybe (catMaybes, fromMaybe)
+import qualified Data.Text as Text
+import qualified Data.Text.Encoding as Text
+import Data.Word (Word16)
+import Squeal.PostgreSQL (PQ)
+import qualified Squeal.PostgreSQL as PQ
+import System.Environment (lookupEnv)
+import Text.Read (readMaybe)
+
+import Starter.Database.Schema (AppDb)
+
+data DbConfig = DbConfig
+  { dbHost :: Text
+  , dbPort :: Word16
+  , dbName :: Text
+  , dbUser :: Text
+  , dbPassword :: Maybe Text
+  }
+  deriving stock (Eq, Show)
+
+-- | Default configuration useful for local development and tests.
+defaultDbConfig :: DbConfig
+defaultDbConfig =
+  DbConfig
+    { dbHost = "localhost"
+    , dbPort = 5432
+    , dbName = "hs_starter"
+    , dbUser = "postgres"
+    , dbPassword = Nothing
+    }
+
+-- | Load connection parameters from environment variables, falling back to sensible defaults.
+loadDbConfigFromEnv :: IO DbConfig
+loadDbConfigFromEnv = do
+  host <- lookupEnvText "DB_HOST" (dbHost defaultDbConfig)
+  port <- lookupEnvPort "DB_PORT" (dbPort defaultDbConfig)
+  name <- lookupEnvText "DB_NAME" (dbName defaultDbConfig)
+  user <- lookupEnvText "DB_USER" (dbUser defaultDbConfig)
+  password <- lookupEnvTextOptional "DB_PASSWORD"
+  pure
+    DbConfig
+      { dbHost = host
+      , dbPort = port
+      , dbName = name
+      , dbUser = user
+      , dbPassword = password
+      }
+
+-- | Render the configuration into a libpq style connection string for Squeal.
+renderConnectionString :: DbConfig -> ByteString
+renderConnectionString config =
+  let
+    hostPart = "host=" <> dbHost config
+    portPart = "port=" <> Text.pack (show (dbPort config))
+    namePart = "dbname=" <> dbName config
+    userPart = "user=" <> dbUser config
+    passwordPart = ("password=" <>) <$> dbPassword config
+  in
+    Text.encodeUtf8 . Text.unwords $
+      catMaybes
+        [ Just hostPart
+        , Just portPart
+        , Just namePart
+        , Just userPart
+        , passwordPart
+        ]
+
+withAppConnection :: DbConfig -> PQ AppDb AppDb IO a -> IO a
+withAppConnection config action =
+  PQ.withConnection (renderConnectionString config) action
+
+lookupEnvText :: String -> Text -> IO Text
+lookupEnvText name fallback = do
+  value <- lookupEnv name
+  pure $ maybe fallback Text.pack value
+
+lookupEnvTextOptional :: String -> IO (Maybe Text)
+lookupEnvTextOptional name = do
+  value <- lookupEnv name
+  pure $ case value of
+    Nothing -> Nothing
+    Just val | null val -> Nothing
+    Just val -> Just (Text.pack val)
+
+lookupEnvPort :: String -> Word16 -> IO Word16
+lookupEnvPort name fallback = do
+  value <- lookupEnv name
+  pure $ fromMaybe fallback (value >>= readMaybe)

--- a/src/Starter/Database/Generated.hs
+++ b/src/Starter/Database/Generated.hs
@@ -1,0 +1,71 @@
+-- | This code was originally created by squealgen. Edit if you know how it got made and are willing to own it now.
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE OverloadedLabels #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE GADTs #-}
+{-# OPTIONS_GHC -fno-warn-unticked-promoted-constructors #-}
+
+module Starter.Database.Generated where
+import Squeal.PostgreSQL
+import GHC.TypeLits(Symbol)
+
+type PGltree = UnsafePGType "ltree"
+type PGcidr = UnsafePGType "cidr"
+type PGltxtquery = UnsafePGType "ltxtquery"
+type PGlquery = UnsafePGType "lquery"
+
+
+type DB = '["public" ::: Schema]
+
+type Schema = Join Tables (Join Views (Join Enums (Join Functions (Join Composites Domains))))
+-- enums
+
+-- decls
+type Enums =
+  ('[] :: [(Symbol,SchemumType)])
+
+type Composites =
+  ('[] :: [(Symbol,SchemumType)])
+
+-- schema
+type Tables = ('[
+   "oauth_login_events" ::: 'Table OauthLoginEventsTable
+  ,"users" ::: 'Table UsersTable]  :: [(Symbol,SchemumType)])
+
+-- defs
+type OauthLoginEventsColumns = '["id" ::: 'Def :=> 'NotNull PGint4
+  ,"provider" ::: 'NoDef :=> 'NotNull PGtext
+  ,"raw_payload" ::: 'NoDef :=> 'NotNull PGjsonb
+  ,"logged_at" ::: 'Def :=> 'NotNull PGtimestamptz
+  ,"user_id" ::: 'NoDef :=> 'NotNull PGint4]
+type OauthLoginEventsConstraints = '["oauth_login_events_pkey" ::: 'PrimaryKey '["id"]
+  ,"oauth_login_events_user_id_fkey" ::: 'ForeignKey '["user_id"] "public" "users" '["id"]]
+type OauthLoginEventsTable = OauthLoginEventsConstraints :=> OauthLoginEventsColumns
+
+type UsersColumns = '["id" ::: 'Def :=> 'NotNull PGint4
+  ,"email" ::: 'NoDef :=> 'Null PGtext
+  ,"display_name" ::: 'NoDef :=> 'Null PGtext
+  ,"avatar_url" ::: 'NoDef :=> 'Null PGtext
+  ,"created_at" ::: 'Def :=> 'NotNull PGtimestamptz
+  ,"updated_at" ::: 'Def :=> 'NotNull PGtimestamptz
+  ,"provider" ::: 'NoDef :=> 'NotNull PGtext
+  ,"subject" ::: 'NoDef :=> 'NotNull PGtext]
+type UsersConstraints = '["users_pkey" ::: 'PrimaryKey '["id"]
+  ,"users_provider_subject_key" ::: 'Unique '["provider","subject"]]
+type UsersTable = UsersConstraints :=> UsersColumns
+
+-- VIEWS
+type Views = 
+  '[]
+
+
+-- functions
+type Functions = 
+  '[  ]
+type Domains = '[]
+

--- a/src/Starter/Database/Schema.hs
+++ b/src/Starter/Database/Schema.hs
@@ -1,0 +1,11 @@
+module Starter.Database.Schema
+  ( AppSchema
+  , AppDb
+  ) where
+
+import Squeal.PostgreSQL (Public)
+
+import Starter.Database.Generated (AppSchema)
+
+-- | Public database containing the application schema.
+type AppDb = Public AppSchema

--- a/src/Starter/Prelude.hs
+++ b/src/Starter/Prelude.hs
@@ -1,0 +1,15 @@
+module Starter.Prelude
+  ( module Export
+  ) where
+
+import Prelude as Export hiding (log)
+
+import Control.Applicative as Export
+import Control.Concurrent as Export
+import Control.Monad as Export
+import Data.Function as Export
+import Data.Functor as Export hiding (unzip)
+import Data.Int as Export
+import Data.Text as Export (Text)
+import Data.Traversable as Export
+import GHC.Generics as Export

--- a/src/Starter/Server.hs
+++ b/src/Starter/Server.hs
@@ -1,0 +1,31 @@
+module Starter.Server
+  ( app
+  , apiProxy
+  , Api
+  , HealthStatus (..)
+  ) where
+
+import Starter.Prelude
+
+import Data.Aeson (ToJSON (..), object, (.=))
+import Servant
+
+-- | API type definition for the Servant server.
+type Api = Get '[JSON] HealthStatus
+
+newtype HealthStatus = HealthStatus
+  { status :: Text
+  }
+  deriving stock (Eq, Show, Generic)
+
+instance ToJSON HealthStatus where
+  toJSON HealthStatus {status} = object ["status" .= status]
+
+apiProxy :: Proxy Api
+apiProxy = Proxy
+
+server :: Server Api
+server = pure (HealthStatus "ok")
+
+app :: env -> Application
+app _env = serve apiProxy server

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -1,0 +1,20 @@
+module Main (main) where
+
+import Starter.Prelude
+
+import qualified Starter.Tests.Db as Db
+import qualified Starter.Tests.Property as Property
+import Test.Tasty (TestTree, defaultMain, testGroup)
+import Test.Tasty.HUnit ((@?=), testCase)
+
+main :: IO ()
+main = defaultMain allTests
+
+allTests :: TestTree
+allTests =
+  testGroup
+    "Starter"
+    [ testCase "bootstrap sanity" (True @?= True)
+    , Property.tests
+    , Db.tests
+    ]

--- a/test/Starter/Tests/Db.hs
+++ b/test/Starter/Tests/Db.hs
@@ -1,0 +1,35 @@
+module Starter.Tests.Db
+  ( tests
+  ) where
+
+import Starter.Prelude
+
+import Control.Exception (SomeException, catch, displayException)
+import qualified Database.Postgres.Temp as Temp
+import qualified Squeal.PostgreSQL as PQ
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit (testCase)
+
+-- | Ensure tmp-postgres instances boot and accept Squeal connections.
+tests :: TestTree
+tests =
+  testGroup
+    "tmp-postgres"
+    [ testCase "connects" tmpPostgresConnects
+    ]
+
+tmpPostgresConnects :: IO ()
+tmpPostgresConnects = do
+  startResult <- catch (Right <$> Temp.start) handler
+  case startResult of
+    Left msg -> putStrLn msg
+    Right (Left err) ->
+      putStrLn $ "tmp-postgres unavailable, skipping test: " <> show err
+    Right (Right db) -> do
+      let connString = Temp.toConnectionString db
+      PQ.withConnection connString (pure ())
+      Temp.stop db
+
+handler :: SomeException -> IO (Either String (Either Temp.StartError Temp.DB))
+handler exc =
+  pure . Left $ "tmp-postgres unavailable, skipping test: " <> displayException exc

--- a/test/Starter/Tests/Property.hs
+++ b/test/Starter/Tests/Property.hs
@@ -1,0 +1,26 @@
+module Starter.Tests.Property
+  ( tests
+  ) where
+
+import Starter.Prelude
+
+import qualified Test.Falsify.Generator as Gen
+import qualified Test.Falsify.Range as Range
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.Falsify (Property, gen, testFailed, testProperty)
+
+-- | Property: addition is commutative for Int32.
+tests :: TestTree
+tests =
+  testGroup
+    "Property"
+    [ testProperty "addition commutative" additionCommutative
+    ]
+
+additionCommutative :: Property ()
+additionCommutative = do
+  x <- gen (Gen.inRange (Range.withOrigin (-10_000, 10_000) (0 :: Int32)))
+  y <- gen (Gen.inRange (Range.withOrigin (-10_000, 10_000) (0 :: Int32)))
+  unless (x + y == y + x) $ do
+    let detail = "addition failed for: " <> show (x, y)
+    testFailed detail


### PR DESCRIPTION
## Summary
- import starter application, migrations, and generated database types
- add server entrypoints, scripts, and tasty test scaffolding
- include CI workflow and repo configuration files

## Testing
- not run (initial import)