### PR TITLE
stage: implement oauth flow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,7 @@ Format Haskell with `ormolu` (`cabal run ormolu -- --mode inplace $(git ls-files
 
 ## Database & Migrations Workflow
 Author schema changes in pgroll YAML first and append new files to `db/pgroll/.ledger`. After running migrations (see `scripts/squealgen.sh`), regenerate Haskell types with the upstream `squealgen` CLI. Never hand-edit `Starter.Database.Generated`; treat it as a build artifact.
+All database interaction must use Squeal; do not introduce alternative PostgreSQL clients.
 
 ## Testing Guidelines
 `cabal test` runs tasty with falsify properties and tmp-postgres-backed smoke checks. Property suites live under `Starter.Tests.Property`; integration helpers use `Starter.Tests.Db`. When introducing new DB features, add tmp-postgres coverage or document why it is skipped. Target >85% coverage once the suite expands and note any regressions in PRs.

--- a/hs-starter.cabal
+++ b/hs-starter.cabal
@@ -26,8 +26,11 @@ library
     hs-source-dirs: src
     exposed-modules:
         Starter.Application
+        Starter.Database.OAuth
         Starter.Database.Connection
         Starter.Database.Schema
+        Starter.Env
+        Starter.OAuth.Types
         Starter.Prelude
         Starter.Server
     other-modules:
@@ -36,13 +39,16 @@ library
         aeson >=2.2 && <2.3,
         bytestring >=0.11 && <0.13,
         hashable >=1.4 && <1.5,
+        generics-sop >=0.5 && <0.6,
         hs-opentelemetry-instrumentation-servant >=0.2 && <0.3,
         hs-opentelemetry-instrumentation-wai >=0.1 && <0.2,
         hs-opentelemetry-sdk >=0.1 && <0.2,
+        time >=1.12 && <1.15,
         servant-server >=0.20 && <0.21,
         squeal-postgresql >=0.9.2 && <0.10,
         text >=2.0 && <2.2,
         unliftio >=0.2 && <0.3,
+        uuid >=1.3 && <1.4,
         wai >=3.2 && <3.3,
         warp >=3.4 && <3.5
 

--- a/src/Starter/Database/OAuth.hs
+++ b/src/Starter/Database/OAuth.hs
@@ -1,0 +1,132 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE OverloadedLabels #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
+
+module Starter.Database.OAuth
+  ( insertSession
+  , selectSession
+  , deleteSession
+  , upsertUser
+  , insertLoginEvent
+  , OAuthSessionRow (..)
+  , DbUserRow (..)
+  ) where
+
+import Starter.Prelude hiding (from)
+
+import Data.Aeson (Value)
+import Data.Time (UTCTime)
+import qualified GHC.Generics as GHC
+import qualified Generics.SOP as SOP
+import Squeal.PostgreSQL
+
+import Starter.Database.Schema (AppDb)
+
+-- | Representation of a staged OAuth session stored in Postgres.
+data OAuthSessionRow = OAuthSessionRow
+  { sessionState :: Text
+  , sessionCodeVerifier :: Text
+  , sessionProvider :: Text
+  , sessionRedirectUri :: Text
+  , sessionRequestedScopes :: Text
+  }
+  deriving stock (Eq, Show, GHC.Generic)
+  deriving anyclass (SOP.Generic, SOP.HasDatatypeInfo)
+
+-- | User metadata returned from upserting the users table.
+data DbUserRow = DbUserRow
+  { userId :: Int32
+  , userAllowed :: Bool
+  }
+  deriving stock (Eq, Show, GHC.Generic)
+  deriving anyclass (SOP.Generic, SOP.HasDatatypeInfo)
+
+-- | Persist a new OAuth session for the client.
+insertSession :: Manipulation_ AppDb (Text, Text, Text, Text, Text) ()
+insertSession =
+  insertInto (#public ! #oauth_sessions)
+    ( Values_
+        ( Set (param @1) `as` #state
+            :* Set (param @2) `as` #code_verifier
+            :* Set (param @3) `as` #provider
+            :* Set (param @4) `as` #redirect_uri
+            :* Set (param @5) `as` #requested_scopes
+            :* Default `as` #created_at
+        )
+    )
+    OnConflictDoRaise
+    (Returning_ Nil)
+
+-- | Fetch a stored OAuth session by state handle.
+selectSession :: Statement AppDb (Only Text) OAuthSessionRow
+selectSession =
+  query $
+    select_
+      ( #oauth_sessions ! #state `as` #sessionState
+          :* #oauth_sessions ! #code_verifier `as` #sessionCodeVerifier
+          :* #oauth_sessions ! #provider `as` #sessionProvider
+          :* #oauth_sessions ! #redirect_uri `as` #sessionRedirectUri
+          :* #oauth_sessions ! #requested_scopes `as` #sessionRequestedScopes
+      )
+      ( from (table (#public ! #oauth_sessions `as` #oauth_sessions))
+          & where_ (#oauth_sessions ! #state .== param @1)
+      )
+
+-- | Clear an OAuth session once it has been consumed.
+deleteSession :: Manipulation_ AppDb (Only Text) ()
+deleteSession =
+  deleteFrom #oauth_sessions NoUsing (#state .== param @1) (Returning_ Nil)
+
+-- | Upsert a user record based on the OAuth identity.
+upsertUser :: Manipulation_ AppDb (Text, Text, Maybe Text, Maybe Text, Maybe Text, Bool, Maybe UTCTime, UTCTime) DbUserRow
+upsertUser =
+  insertInto (#public ! #users `as` #u)
+    ( Values_
+        ( Default `as` #id
+            :* Set (param @3) `as` #email
+            :* Set (param @4) `as` #display_name
+            :* Set (param @5) `as` #avatar_url
+            :* Default `as` #created_at
+            :* Set (param @8) `as` #updated_at
+            :* Set (param @1) `as` #provider
+            :* Set (param @2) `as` #subject
+            :* Set (param @6) `as` #allowed
+            :* Set (param @7) `as` #last_login_at
+        )
+    )
+    ( OnConflict (OnConstraint #users_provider_subject_key)
+        ( DoUpdate
+            ( Set (param @3) `as` #email
+                :* Set (param @4) `as` #display_name
+                :* Set (param @5) `as` #avatar_url
+                :* Set (param @8) `as` #updated_at
+                :* Set (param @6) `as` #allowed
+                :* Set (param @7) `as` #last_login_at
+                :* Nil
+            )
+            [ #u ! #provider .== param @1
+            , #u ! #subject .== param @2
+            ]
+        )
+    )
+    ( Returning_ (#u ! #id `as` #userId :* #u ! #allowed `as` #userAllowed)
+    )
+
+-- | Record a login attempt in the oauth_login_events audit table.
+insertLoginEvent :: Manipulation_ AppDb (Int32, Text, Jsonb Value, Bool, UTCTime) ()
+insertLoginEvent =
+  insertInto (#public ! #oauth_login_events)
+    ( Values_
+        ( Default `as` #id
+            :* Set (param @2) `as` #provider
+            :* Set (param @3) `as` #raw_payload
+            :* Set (param @5) `as` #logged_at
+            :* Set (param @1) `as` #user_id
+            :* Set (param @4) `as` #allowed
+        )
+    )
+    OnConflictDoRaise
+    (Returning_ Nil)

--- a/src/Starter/Env.hs
+++ b/src/Starter/Env.hs
@@ -1,0 +1,18 @@
+module Starter.Env
+  ( AppEnv (..)
+  ) where
+
+import Starter.Prelude
+
+import Starter.Database.Connection (DbConfig)
+import Starter.OAuth.Types (OAuthProfile)
+
+-- | Global environment values shared across the application runtime.
+data AppEnv = AppEnv
+  { appPort :: Int
+  , otelServiceName :: Text
+  , otelCollectorEndpoint :: Maybe String
+  , otelCollectorHeaders :: Maybe String
+  , dbConfig :: DbConfig
+  , authorizeLogin :: OAuthProfile -> IO Bool
+  }

--- a/src/Starter/OAuth/Types.hs
+++ b/src/Starter/OAuth/Types.hs
@@ -1,0 +1,58 @@
+{-# LANGUAGE DuplicateRecordFields #-}
+
+module Starter.OAuth.Types
+  ( OAuthStartRequest (..)
+  , OAuthStartResponse (..)
+  , OAuthProfile (..)
+  , OAuthCallbackRequest (..)
+  , OAuthCallbackResponse (..)
+  ) where
+
+import Starter.Prelude
+
+import Data.Aeson (FromJSON, ToJSON)
+
+-- | Parameters required to initiate an OAuth login flow.
+data OAuthStartRequest = OAuthStartRequest
+  { redirectUri :: Text
+  , scopes :: [Text]
+  }
+  deriving stock (Eq, Show, Generic)
+  deriving anyclass (FromJSON, ToJSON)
+
+-- | Response returned after staging an OAuth authorization redirect.
+data OAuthStartResponse = OAuthStartResponse
+  { state :: Text
+  , codeVerifier :: Text
+  , authorizationUrl :: Text
+  }
+  deriving stock (Eq, Show, Generic)
+  deriving anyclass (ToJSON)
+
+-- | Minimal profile data returned by an OAuth provider.
+data OAuthProfile = OAuthProfile
+  { subject :: Text
+  , email :: Maybe Text
+  , displayName :: Maybe Text
+  , avatarUrl :: Maybe Text
+  }
+  deriving stock (Eq, Show, Generic)
+  deriving anyclass (FromJSON, ToJSON)
+
+-- | Callback payload delivered by the OAuth provider.
+data OAuthCallbackRequest = OAuthCallbackRequest
+  { state :: Text
+  , code :: Text
+  , profile :: OAuthProfile
+  }
+  deriving stock (Eq, Show, Generic)
+  deriving anyclass (FromJSON, ToJSON)
+
+-- | Response indicating whether the user may proceed with login.
+data OAuthCallbackResponse = OAuthCallbackResponse
+  { allowed :: Bool
+  , redirectUri :: Text
+  , userId :: Int32
+  }
+  deriving stock (Eq, Show, Generic)
+  deriving anyclass (ToJSON)

--- a/src/Starter/Server.hs
+++ b/src/Starter/Server.hs
@@ -1,21 +1,69 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE OverloadedLabels #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
+
 module Starter.Server
   ( app
   , apiProxy
   , Api
+  , HealthApi
+  , OAuthApi
   , server
+  , healthServer
   , HealthStatus (..)
   ) where
 
 import Starter.Prelude
 
 import Data.Aeson (ToJSON (..), object, (.=))
+import qualified Data.Aeson as Aeson
 import Data.Hashable (Hashable)
+import Data.Maybe (listToMaybe)
+import qualified Data.Text as Text
+import Data.Time (UTCTime, getCurrentTime)
+import qualified Data.UUID as UUID
+import qualified Data.UUID.V4 as UUID
+import Control.Monad.IO.Class (liftIO)
 import Servant
+import Squeal.PostgreSQL (Jsonb (..))
+import qualified Squeal.PostgreSQL as PQ
+
+import Starter.Database.Connection (withAppConnection)
+import Starter.Database.OAuth
+  ( DbUserRow (..)
+  , OAuthSessionRow (..)
+  , deleteSession
+  , insertLoginEvent
+  , insertSession
+  , selectSession
+  , upsertUser
+  )
+import Starter.Env (AppEnv (..))
+import Starter.OAuth.Types
+  ( OAuthCallbackRequest (..)
+  , OAuthCallbackResponse (..)
+  , OAuthProfile (..)
+  , OAuthStartRequest (..)
+  , OAuthStartResponse (..)
+  )
 
 -- | API type definition for the Servant server.
-type Api = Get '[JSON] HealthStatus
+type HealthApi = "health" :> Get '[JSON] HealthStatus
 
-newtype HealthStatus = HealthStatus
+type OAuthApi =
+  "oauth"
+    :> Capture "provider" Text
+    :> ( "start" :> ReqBody '[JSON] OAuthStartRequest :> Post '[JSON] OAuthStartResponse
+          :<|> "callback" :> ReqBody '[JSON] OAuthCallbackRequest :> Post '[JSON] OAuthCallbackResponse
+       )
+
+type Api = HealthApi :<|> OAuthApi
+
+data HealthStatus = HealthStatus
   { status :: Text
   }
   deriving stock (Eq, Show, Generic)
@@ -27,8 +75,106 @@ instance ToJSON HealthStatus where
 apiProxy :: Proxy Api
 apiProxy = Proxy
 
-server :: Server Api
-server = pure (HealthStatus "ok")
+app :: AppEnv -> Application
+app env = serve apiProxy (server env)
 
-app :: env -> Application
-app _env = serve apiProxy server
+server :: AppEnv -> Server Api
+server env = healthServer :<|> oauthServer env
+
+healthServer :: Server HealthApi
+healthServer = pure (HealthStatus "ok")
+
+oauthServer :: AppEnv -> Server OAuthApi
+oauthServer env provider =
+  startHandler env provider :<|> callbackHandler env provider
+
+startHandler :: AppEnv -> Text -> OAuthStartRequest -> Handler OAuthStartResponse
+startHandler env provider OAuthStartRequest {redirectUri = redirectUriValue, scopes} = do
+  stateValue <- liftIO randomState
+  codeVerifier <- liftIO randomVerifier
+  let requestedScopes = Text.intercalate " " scopes
+  liftIO $ withAppConnection (dbConfig env) $ do
+    PQ.manipulateParams_ insertSession (stateValue, codeVerifier, provider, redirectUriValue, requestedScopes)
+  let authorizationUrl = buildAuthorizationUrl provider redirectUriValue stateValue requestedScopes
+  pure OAuthStartResponse {state = stateValue, codeVerifier, authorizationUrl}
+
+callbackHandler :: AppEnv -> Text -> OAuthCallbackRequest -> Handler OAuthCallbackResponse
+callbackHandler env provider request@OAuthCallbackRequest {state = callbackState, profile = callbackProfile} = do
+  sessionRow <- liftIO (loadSession env callbackState) >>= maybe (throwError err400 {errBody = "unknown oauth state"}) pure
+  when (sessionProvider sessionRow /= provider) $
+    throwError err400 {errBody = "provider mismatch"}
+  allowed <- liftIO (authorizeLogin env callbackProfile)
+  now <- liftIO getCurrentTime
+  dbUser <-
+    liftIO (upsertUserRecord env provider callbackProfile allowed now)
+      >>= maybe (throwError err500 {errBody = "failed to upsert user"}) pure
+  liftIO $ recordLogin env dbUser provider request allowed now
+  liftIO $ clearSession env callbackState
+  let DbUserRow {userId = dbUserId} = dbUser
+  pure
+    OAuthCallbackResponse
+      { allowed
+      , redirectUri = sessionRedirectUri sessionRow
+      , userId = dbUserId
+      }
+
+loadSession :: AppEnv -> Text -> IO (Maybe OAuthSessionRow)
+loadSession env stateValue =
+  withAppConnection (dbConfig env) $ do
+    result <- PQ.executeParams selectSession (PQ.Only stateValue)
+    rows <- PQ.getRows result
+    pure (listToMaybe rows)
+
+upsertUserRecord :: AppEnv -> Text -> OAuthProfile -> Bool -> UTCTime -> IO (Maybe DbUserRow)
+upsertUserRecord env provider OAuthProfile {subject, email, displayName, avatarUrl} allowed now =
+  withAppConnection (dbConfig env) $ do
+    result <-
+      PQ.manipulateParams
+        upsertUser
+        ( provider
+        , subject
+        , email
+        , displayName
+        , avatarUrl
+        , allowed
+        , Just now
+        , now
+        )
+    rows <- PQ.getRows result
+    pure (listToMaybe rows)
+
+recordLogin :: AppEnv -> DbUserRow -> Text -> OAuthCallbackRequest -> Bool -> UTCTime -> IO ()
+recordLogin env DbUserRow {userId = dbUserId} provider payload allowed now =
+  withAppConnection (dbConfig env) $ do
+    PQ.manipulateParams_
+      insertLoginEvent
+      ( dbUserId
+      , provider
+      , Jsonb (Aeson.toJSON payload)
+      , allowed
+      , now
+      )
+
+clearSession :: AppEnv -> Text -> IO ()
+clearSession env stateValue =
+  withAppConnection (dbConfig env) $
+    PQ.manipulateParams_ deleteSession (PQ.Only stateValue)
+
+randomState :: IO Text
+randomState = UUID.toText <$> UUID.nextRandom
+
+randomVerifier :: IO Text
+randomVerifier = UUID.toText <$> UUID.nextRandom
+
+buildAuthorizationUrl :: Text -> Text -> Text -> Text -> Text
+buildAuthorizationUrl provider redirectUri state scopeText =
+  "https://auth.example.com/" <> provider
+    <> "?redirect_uri="
+    <> redirectUri
+    <> "&state="
+    <> state
+    <> scopesFragment
+  where
+    scopesFragment
+      | Text.null scopeText = ""
+      | otherwise = "&scope=" <> Text.replace " " "+" scopeText

--- a/test/Starter/Tests/Roboservant.hs
+++ b/test/Starter/Tests/Roboservant.hs
@@ -12,14 +12,14 @@ import Data.Maybe (isNothing)
 import qualified Roboservant.Server as Robo
 import Roboservant.Types (Atom (..), Breakdown)
 import Roboservant.Types.Config (defaultConfig)
-import Starter.Server (Api, HealthStatus, server)
+import Starter.Server (HealthApi, HealthStatus, healthServer)
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.HUnit (assertBool, testCase)
 
 -- | Run the Roboservant fuzzer against the health check API.
 fuzzesHealthcheck :: IO ()
 fuzzesHealthcheck = do
-  result <- Robo.fuzz @Api server defaultConfig
+  result <- Robo.fuzz @HealthApi healthServer defaultConfig
   assertBool "roboservant found a counterexample" (isNothing result)
 
 tests :: TestTree


### PR DESCRIPTION
## Summary
- define OAuth types, environment wiring, and database manipulations via Squeal
- add /oauth/:provider/start and /oauth/:provider/callback endpoints
- persist staged sessions, upsert users, and audit login attempts

## Testing
- cabal test