### PR TITLE
feat: enrich healthcheck response

### DIFF
--- a/hs-starter.cabal
+++ b/hs-starter.cabal
@@ -34,7 +34,10 @@ library
         Starter.Prelude
         Starter.Server
     other-modules:
+        Paths_hs_starter
         Starter.Database.Generated
+    autogen-modules:
+        Paths_hs_starter
     build-depends:
         aeson >=2.2 && <2.3,
         bytestring >=0.11 && <0.13,
@@ -52,7 +55,8 @@ library
         unliftio >=0.2 && <0.3,
         uuid >=1.3 && <1.4,
         wai >=3.2 && <3.3,
-        warp >=3.4 && <3.5
+        warp >=3.4 && <3.5,
+        unordered-containers >=0.2 && <0.3
 
 executable hs-starter
     import: common-settings
@@ -93,4 +97,5 @@ test-suite hs-starter-tests
         wai-extra >=3.1 && <3.2,
         bytestring >=0.11 && <0.13,
         text >=2.0 && <2.2,
-        process >=1.6 && <1.7
+        process >=1.6 && <1.7,
+        unordered-containers >=0.2 && <0.3

--- a/src/Starter/Server.hs
+++ b/src/Starter/Server.hs
@@ -15,23 +15,25 @@ module Starter.Server
     server,
     healthServer,
     HealthStatus (..),
+    HealthCheckReport (..),
   )
 where
 
-import Control.Exception (SomeException, catch, try)
+import Control.Exception (SomeException, displayException, throwIO, try)
 import Control.Monad.IO.Class (liftIO)
-import Data.Aeson (ToJSON (..), object, (.=))
+import Data.Aeson (FromJSON, ToJSON, Value, encode, object, (.=))
 import Data.Aeson qualified as Aeson
-import Data.Hashable (Hashable)
+import Data.HashMap.Strict qualified as HashMap
 import Data.Maybe (listToMaybe)
 import Data.Text qualified as Text
-import Data.Time (UTCTime, getCurrentTime)
+import Data.Time (UTCTime, diffUTCTime, getCurrentTime)
 import Data.UUID qualified as UUID
 import Data.UUID.V4 qualified as UUID
+import Data.Version (showVersion)
 import Servant
 import Squeal.PostgreSQL (Jsonb (..))
 import Squeal.PostgreSQL qualified as PQ
-import Starter.Database.Connection (withAppConnection)
+import Starter.Database.Connection (DbConfig (..), withAppConnection)
 import Starter.Database.OAuth
   ( DbUserRow (..),
     OAuthSessionRow (..),
@@ -51,6 +53,7 @@ import Starter.OAuth.Types
     OAuthStartResponse (..),
   )
 import Starter.Prelude
+import Paths_hs_starter qualified as Paths
 
 -- | API type definition for the Servant server.
 type HealthApi = "health" :> Get '[JSON] HealthStatus
@@ -65,13 +68,37 @@ type OAuthApi =
 type Api = HealthApi :<|> OAuthApi
 
 data HealthStatus = HealthStatus
-  { status :: Text
+  { status :: Text,
+    timestamp :: UTCTime,
+    service :: Text,
+    version :: Text,
+    checks :: HashMap.HashMap Text HealthCheckReport
   }
   deriving stock (Eq, Show, Generic)
-  deriving anyclass (Hashable)
+  deriving anyclass (ToJSON, FromJSON)
 
-instance ToJSON HealthStatus where
-  toJSON HealthStatus {status} = object ["status" .= status]
+data HealthCheckReport = HealthCheckReport
+  { status :: Text,
+    observedAt :: UTCTime,
+    durationMs :: Double,
+    details :: Value
+  }
+  deriving stock (Eq, Show, Generic)
+  deriving anyclass (ToJSON, FromJSON)
+
+data ErrorResponse = ErrorResponse
+  { error :: ErrorBody
+  }
+  deriving stock (Eq, Show, Generic)
+  deriving anyclass (ToJSON)
+
+data ErrorBody = ErrorBody
+  { code :: Text,
+    message :: Text,
+    details :: Value
+  }
+  deriving stock (Eq, Show, Generic)
+  deriving anyclass (ToJSON)
 
 apiProxy :: Proxy Api
 apiProxy = Proxy
@@ -84,15 +111,78 @@ server env = healthServer env :<|> oauthServer env
 
 healthServer :: AppEnv -> Server HealthApi
 healthServer env = do
-  eok <- liftIO $ try $ withAppConnection (dbConfig env) $ do
-    result <- PQ.executeParams selectUserCount ()
-    rows <- PQ.getRows result
-    case rows of
-      [PQ.Only _n] -> pure ()
-      _ -> pure ()
-  case eok of
-    Left (_ex :: SomeException) -> throwError err500 {errBody = "database check failed"}
-    Right () -> pure (HealthStatus "ok")
+  timestamp <- liftIO getCurrentTime
+  let dbCfg = dbConfig env
+      versionText = Text.pack (showVersion Paths.version)
+      databaseDetails =
+        object
+          [ "host" .= dbHost dbCfg,
+            "port" .= dbPort dbCfg,
+            "database" .= dbName dbCfg,
+            "user" .= dbUser dbCfg
+          ]
+  checkStartedAt <- liftIO getCurrentTime
+  dbResult <-
+    liftIO . try @SomeException $ withAppConnection dbCfg $ do
+      result <- PQ.executeParams selectUserCount ()
+      rows <- PQ.getRows result
+      case rows of
+        [PQ.Only count] -> pure count
+        unexpected ->
+          liftIO
+            $ throwIO
+              ( userError
+                  ("unexpected result from selectUserCount: " <> show unexpected)
+              )
+  checkCompletedAt <- liftIO getCurrentTime
+  let durationMs :: Double
+      durationMs = realToFrac (diffUTCTime checkCompletedAt checkStartedAt) * 1000
+  case dbResult of
+    Left (ex :: SomeException) ->
+      let errorPayload =
+            ErrorResponse
+              { error =
+                  ErrorBody
+                    { code = "DATABASE_CHECK_FAILED",
+                      message = "Database connectivity check failed",
+                      details =
+                        object
+                          [ "timestamp" .= timestamp,
+                            "service" .= otelServiceName env,
+                            "version" .= versionText,
+                            "observedAt" .= checkCompletedAt,
+                            "durationMs" .= durationMs,
+                            "database" .= databaseDetails,
+                            "exception" .= displayException ex
+                          ]
+                    }
+              }
+       in throwError
+            err500
+              { errBody = encode errorPayload,
+                errHeaders = [("Content-Type", "application/json; charset=utf-8")]
+              }
+    Right count ->
+      let databaseReport =
+            HealthCheckReport
+              { status = "ok",
+                observedAt = checkCompletedAt,
+                durationMs = durationMs,
+                details =
+                  object
+                    [ "message" .= ("Successfully queried user count" :: Text),
+                      "rowCount" .= count,
+                      "database" .= databaseDetails
+                    ]
+              }
+       in pure
+            HealthStatus
+              { status = "ok",
+                timestamp = timestamp,
+                service = otelServiceName env,
+                version = versionText,
+                checks = HashMap.fromList [("database", databaseReport)]
+              }
 
 oauthServer :: AppEnv -> Server OAuthApi
 oauthServer env provider =


### PR DESCRIPTION
## Summary
- enrich /health response with version, timestamp, and per-check details
- return structured error payload when the database probe fails
- update the health integration test to assert the richer payload contents

## Testing
- cabal build
