### PR TITLE
chore: ensure ghcup env is loaded in docker builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -73,6 +73,7 @@ RUN apt-get update \
 COPY --from=build /opt/app/bin/hs-starter /usr/local/bin/hs-starter
 COPY --from=build /opt/app/bin/pgroll /usr/local/bin/pgroll
 COPY --from=build /workspace/db/pgroll ${APP_HOME}/db/pgroll
+COPY --from=build /workspace/scripts ${APP_HOME}/scripts
 
 EXPOSE 8080
 ENTRYPOINT ["/bin/bash", "-lc"]

--- a/app.json
+++ b/app.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
     "dokku": {
-      "predeploy": "set -euo pipefail; ls -al /opt/app/db/pgroll; pgroll init --postgres-url \"$DATABASE_URL\" --schema public --pgroll-schema pgroll; pgroll migrate /opt/app/db/pgroll --postgres-url \"$DATABASE_URL\" --schema public --pgroll-schema pgroll --complete"
+      "predeploy": "/bin/bash /opt/app/scripts/dokku-predeploy.sh"
     }
   }
 }

--- a/app.json
+++ b/app.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
     "dokku": {
-      "predeploy": "set -euo pipefail; pgroll init --postgres-url \"$DATABASE_URL\" --schema public --pgroll-schema pgroll --log-level=debug; pgroll migrate db/pgroll --postgres-url \"$DATABASE_URL\" --schema public --pgroll-schema pgroll --complete --log-level=debug"
+      "predeploy": "set -euo pipefail; pgroll init --postgres-url \"$DATABASE_URL\" --schema public --pgroll-schema pgroll --log-level=debug; pgroll migrate /opt/app/db/pgroll --postgres-url \"$DATABASE_URL\" --schema public --pgroll-schema pgroll --complete --log-level=debug"
     }
   }
 }

--- a/app.json
+++ b/app.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
     "dokku": {
-      "predeploy": "/bin/bash /opt/app/scripts/dokku-predeploy.sh"
+      "predeploy": "/opt/app/scripts/dokku-predeploy.sh"
     }
   }
 }

--- a/app.json
+++ b/app.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
     "dokku": {
-      "predeploy": "set -euo pipefail; pgroll init --postgres-url \"$DATABASE_URL\" --schema public --pgroll-schema pgroll --log-level=debug; pgroll migrate /opt/app/db/pgroll --postgres-url \"$DATABASE_URL\" --schema public --pgroll-schema pgroll --complete --log-level=debug"
+      "predeploy": "set -euo pipefail; ls -al /opt/app/db/pgroll; pgroll init --postgres-url \"$DATABASE_URL\" --schema public --pgroll-schema pgroll --log-level=debug; pgroll migrate /opt/app/db/pgroll --postgres-url \"$DATABASE_URL\" --schema public --pgroll-schema pgroll --complete --log-level=debug"
     }
   }
 }

--- a/app.json
+++ b/app.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
     "dokku": {
-      "predeploy": "bash -lc 'set -euo pipefail && pgroll migrate db/pgroll --postgres-url \"$DATABASE_URL\" --schema public --pgroll-schema pgroll --complete'"
+      "predeploy": "set -euo pipefail; pgroll init --postgres-url \"$DATABASE_URL\" --schema public --pgroll-schema pgroll --log-level=debug; pgroll migrate db/pgroll --postgres-url \"$DATABASE_URL\" --schema public --pgroll-schema pgroll --complete --log-level=debug"
     }
   }
 }

--- a/app.json
+++ b/app.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
     "dokku": {
-      "predeploy": "set -euo pipefail; ls -al /opt/app/db/pgroll; pgroll init --postgres-url \"$DATABASE_URL\" --schema public --pgroll-schema pgroll --log-level=debug; pgroll migrate /opt/app/db/pgroll --postgres-url \"$DATABASE_URL\" --schema public --pgroll-schema pgroll --complete --log-level=debug"
+      "predeploy": "set -euo pipefail; ls -al /opt/app/db/pgroll; pgroll init --postgres-url \"$DATABASE_URL\" --schema public --pgroll-schema pgroll; pgroll migrate /opt/app/db/pgroll --postgres-url \"$DATABASE_URL\" --schema public --pgroll-schema pgroll --complete"
     }
   }
 }

--- a/scripts/dokku-predeploy.sh
+++ b/scripts/dokku-predeploy.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+echo "Starting migrations"
+
 MIGRATIONS_DIR="/opt/app/db/pgroll"
 
 if [[ ! -d "$MIGRATIONS_DIR" ]]; then

--- a/scripts/dokku-predeploy.sh
+++ b/scripts/dokku-predeploy.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-echo "Starting migrations"
+echo "Starting migrations" >&2
 
 MIGRATIONS_DIR="/opt/app/db/pgroll"
 
@@ -10,16 +10,16 @@ if [[ ! -d "$MIGRATIONS_DIR" ]]; then
   exit 1
 fi
 
-echo "==> Listing pgroll migrations in $MIGRATIONS_DIR"
+echo "==> Listing pgroll migrations in $MIGRATIONS_DIR" >&2
 ls -al "$MIGRATIONS_DIR"
 
-echo "==> Running pgroll init"
+echo "==> Running pgroll init" >&2
 pgroll init \
   --postgres-url "$DATABASE_URL" \
   --schema public \
   --pgroll-schema pgroll
 
-echo "==> Running pgroll migrate"
+echo "==> Running pgroll migrate" >&2
 pgroll migrate "$MIGRATIONS_DIR" \
   --postgres-url "$DATABASE_URL" \
   --schema public \

--- a/scripts/dokku-predeploy.sh
+++ b/scripts/dokku-predeploy.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+MIGRATIONS_DIR="/opt/app/db/pgroll"
+
+if [[ ! -d "$MIGRATIONS_DIR" ]]; then
+  echo "error: migrations directory '$MIGRATIONS_DIR' not found" >&2
+  exit 1
+fi
+
+echo "==> Listing pgroll migrations in $MIGRATIONS_DIR"
+ls -al "$MIGRATIONS_DIR"
+
+echo "==> Running pgroll init"
+pgroll init \
+  --postgres-url "$DATABASE_URL" \
+  --schema public \
+  --pgroll-schema pgroll
+
+echo "==> Running pgroll migrate"
+pgroll migrate "$MIGRATIONS_DIR" \
+  --postgres-url "$DATABASE_URL" \
+  --schema public \
+  --pgroll-schema pgroll \
+  --complete


### PR DESCRIPTION
## Summary
- source /root/.ghcup/env before running ghcup/cabal commands so the cached ghcup binary is on PATH
- keep the cache mounts while reusing the same env sourcing pattern for all cabal build/install steps

## Testing
- not run (docker build)
