### PR TITLE
chore: run pgroll init before migrations

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
     "dokku": {
-      "predeploy": "bash -lc 'set -euo pipefail && pgroll migrate db/pgroll --postgres-url \"$DATABASE_URL\" --schema public --pgroll-schema pgroll --complete'"
+      "predeploy": "bash -lc 'set -euo pipefail && pgroll init --postgres-url \"$DATABASE_URL\" --schema public --pgroll-schema pgroll && pgroll migrate db/pgroll --postgres-url \"$DATABASE_URL\" --schema public --pgroll-schema pgroll --complete'"
     }
   }
 }


### PR DESCRIPTION
## Summary
- extend the Dokku predeploy hook to run pgroll init before pgroll migrate so new databases are bootstrapped automatically

## Testing
- not run (dokku deploy)
