### PR TITLE
chore: enable BuildKit apt caching

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,3 +30,10 @@ Follow `type: summary` messages (examples: `feat: add oauth login route`, `chore
 ## Environment & Tooling Notes
 Install pgroll, Docker, and the upstream `squealgen` CLI (see https://github.com/mwotton/squealgen) when working migrations; `scripts/squealgen.sh` expects all three plus a local Postgres image. Export sensitive settings via environment variables—not version control. GitHub Actions re-runs Cabal builds/tests with caching, so keep dependencies tidy and regenerate schema files before pushing.
 Provide Firebase client config via `FIREBASE_API_KEY` and (optionally) `FIREBASE_AUTH_DOMAIN`, and set a strong `SESSION_SECRET` so the login exchange can issue signed cookies.
+
+## dokku
+
+if you can't run dokku in your environment, you're likely just missing this alias:
+
+dokku: aliased to bash $HOME/.dokku/contrib/dokku_client.sh
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,13 +3,14 @@
 FROM ubuntu:22.04 AS build
 ARG PGROLL_VERSION=0.14.2
 ENV DEBIAN_FRONTEND=noninteractive
-RUN apt-get update \
+RUN --mount=type=cache,target=/var/cache/apt \
+    --mount=type=cache,target=/var/lib/apt \
+    apt-get update \
     && apt-get install --yes --no-install-recommends \
          curl ca-certificates xz-utils \
          build-essential pkg-config git \
          libgmp-dev libpq-dev zlib1g-dev \
-    && rm -rf /var/lib/apt/lists/* \
- && update-ca-certificates
+    && update-ca-certificates
 
 # Install ghcup, GHC and Cabal
 ENV BOOTSTRAP_HASKELL_NONINTERACTIVE=1 \
@@ -64,11 +65,12 @@ ENV DEBIAN_FRONTEND=noninteractive \
     OTEL_EXPORTER_OTLP_HEADERS=
 WORKDIR ${APP_HOME}
 
-RUN apt-get update \
+RUN --mount=type=cache,target=/var/cache/apt \
+    --mount=type=cache,target=/var/lib/apt \
+    apt-get update \
     && apt-get install --yes --no-install-recommends \
          libgmp10 libtinfo6 libpq5 zlib1g ca-certificates \
-    && rm -rf /var/lib/apt/lists/* \
- && update-ca-certificates
+    && update-ca-certificates
 
 COPY --from=build /opt/app/bin/hs-starter /usr/local/bin/hs-starter
 COPY --from=build /opt/app/bin/pgroll /usr/local/bin/pgroll

--- a/README.md
+++ b/README.md
@@ -27,6 +27,14 @@ When both are present, `DATABASE_URL` takes precedence.
 
 Dokku executes the pgroll migrations during each deploy via `app.json`'s `scripts.dokku.predeploy` hook. Ensure the linked Postgres service exports a `DATABASE_URL`; the container image bundles the `pgroll` CLI so the hook can run `pgroll migrate db/pgroll --postgres-url "$DATABASE_URL" --schema public --pgroll-schema pgroll --complete` before web processes start.
 
+Enable BuildKit on the Dokku host to take advantage of the Dockerfile cache mounts:
+
+```bash
+dokku config:set hs-starter DOCKER_BUILDKIT=1
+```
+
+With BuildKit active, the cached `apt` indexes are reused between builds and the image now provisions dependencies via the cache-aware mounts defined in the Dockerfile.
+
 ## End-to-end Firebase login test
 
 A Playwright regression in `test/playwright/tests/me.spec.js` asserts that fetching `/me` kicks off the Firebase redirect flow and issues a successful `POST` request to `googleapis.com`. Run it with the official Playwright Docker image via:


### PR DESCRIPTION
## Summary
- use BuildKit cache mounts for apt operations in both build and runtime stages
- document enabling DOCKER_BUILDKIT on Dokku to reuse the new cache paths

## Testing
- not run (documentation/build config change)
