### PR TITLE
chore: add dokku build canceller

### DIFF
--- a/scripts/dokku-cancel-build/README.md
+++ b/scripts/dokku-cancel-build/README.md
@@ -1,0 +1,26 @@
+# dokku-cancel-builds helper
+
+This helper wraps the logic needed to terminate in-flight Dokku builds for a single app. The code is split into two layers:
+
+- `remote/cancel-builds-core.sh` contains the cancellation routine and is designed to run on the Dokku host (making it simple to promote into a standalone plugin command later).
+- `cancel-builds` is a thin client that discovers the Dokku host, streams the remote script over SSH, and invokes it with the requested app name.
+
+## Usage
+
+```bash
+scripts/dokku-cancel-build/cancel-builds <app>
+```
+
+Optional flags:
+
+- `--dry-run` – show the actions that would be taken without killing anything.
+- `--host`, `--port`, `--user`, `--ssh-option` – override connection details.
+- `--local` – execute the remote logic locally (useful for developing a Dokku plugin around the same implementation).
+
+The remote routine will:
+
+1. terminate `docker build` / `pack build` processes targeting the app image;
+2. stop any builder containers still running (`/build` commands, pack phases, etc.);
+3. remove the app deploy lock (`/home/dokku/<app>/.deploy.lock`).
+
+When packaged as a plugin, the `cancel-builds-core.sh` implementation can be reused verbatim as the plugin command entrypoint.

--- a/scripts/dokku-cancel-build/cancel-builds
+++ b/scripts/dokku-cancel-build/cancel-builds
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REMOTE_IMPL="$SCRIPT_DIR/remote/cancel-builds-core.sh"
+
+usage() {
+  cat <<'USAGE'
+Usage: cancel-builds [options] <app>
+
+Options:
+  --dry-run            Print actions without executing on the remote host
+  --host <host>        Explicit Dokku hostname (overrides DOKKU_HOST)
+  --port <port>        SSH port (default: 22 or DOKKU_PORT)
+  --user <user>        SSH user (default: dokku)
+  --ssh-option <opt>   Additional ssh option (can be supplied multiple times)
+  --local              Run cancellation logic locally (for plugin packaging/testing)
+  -h, --help           Show this help message
+USAGE
+}
+
+HOST_OVERRIDE=""
+PORT_OVERRIDE=""
+USER_OVERRIDE="dokku"
+DRY_RUN=false
+LOCAL_MODE=false
+SSH_OPTIONS=()
+APP=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dry-run)
+      DRY_RUN=true
+      shift
+      ;;
+    --host)
+      HOST_OVERRIDE="$2"
+      shift 2
+      ;;
+    --port)
+      PORT_OVERRIDE="$2"
+      shift 2
+      ;;
+    --user)
+      USER_OVERRIDE="$2"
+      shift 2
+      ;;
+    --ssh-option)
+      SSH_OPTIONS+=("$2")
+      shift 2
+      ;;
+    --local)
+      LOCAL_MODE=true
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    --)
+      shift
+      APP="${1:-}"
+      break
+      ;;
+    -* )
+      echo "error: unknown option $1" >&2
+      usage
+      exit 1
+      ;;
+    *)
+      APP="$1"
+      shift
+      ;;
+  esac
+done
+
+if [[ -z "$APP" ]]; then
+  echo "error: app name required" >&2
+  usage
+  exit 1
+fi
+
+if [[ ! -f "$REMOTE_IMPL" ]]; then
+  echo "error: remote implementation not found at $REMOTE_IMPL" >&2
+  exit 1
+fi
+
+remote_args=()
+$DRY_RUN && remote_args+=("--dry-run")
+remote_args+=("$APP")
+
+if $LOCAL_MODE; then
+  exec "$REMOTE_IMPL" "${remote_args[@]}"
+fi
+
+resolve_host() {
+  if [[ -n "$HOST_OVERRIDE" ]]; then
+    echo "$HOST_OVERRIDE"
+    return
+  fi
+  if [[ -n "${DOKKU_HOST:-}" ]]; then
+    echo "$DOKKU_HOST"
+    return
+  fi
+  if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    if git remote get-url dokku >/dev/null 2>&1; then
+      local url
+      url=$(git remote get-url dokku)
+      url=${url#ssh://}
+      url=${url#*@}
+      url=${url%%/*}
+      echo "${url%%:*}"
+      return
+    fi
+  fi
+  echo "error: unable to determine Dokku host; set DOKKU_HOST or use --host" >&2
+  exit 1
+}
+
+resolve_port() {
+  if [[ -n "$PORT_OVERRIDE" ]]; then
+    echo "$PORT_OVERRIDE"
+    return
+  fi
+  if [[ -n "${DOKKU_PORT:-}" && "${DOKKU_PORT}" =~ ^[0-9]+$ ]]; then
+    echo "$DOKKU_PORT"
+    return
+  fi
+  if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    if git remote get-url dokku >/dev/null 2>&1; then
+      local url
+      url=$(git remote get-url dokku)
+      url=${url#ssh://}
+      url=${url#*@}
+      url=${url%%/*}
+      local port=${url##*:}
+      if [[ "$port" =~ ^[0-9]+$ ]]; then
+        echo "$port"
+        return
+      fi
+    fi
+  fi
+  echo "22"
+}
+
+HOST=$(resolve_host)
+PORT=$(resolve_port)
+USER="$USER_OVERRIDE"
+
+ssh_command=(ssh -p "$PORT")
+for opt in "${SSH_OPTIONS[@]}"; do
+  ssh_command+=("-o" "$opt")
+done
+ssh_command+=("$USER@$HOST" "--" "bash" "-s" "--")
+
+# shellcheck disable=SC2145
+"${ssh_command[@]}" "${remote_args[@]}" < "$REMOTE_IMPL"
+

--- a/scripts/dokku-cancel-build/remote/cancel-builds-core.sh
+++ b/scripts/dokku-cancel-build/remote/cancel-builds-core.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: cancel-builds-core.sh [options] <app>
+
+Options:
+  --dry-run      Print actions without executing
+  -h, --help     Show this help text
+USAGE
+}
+
+log() {
+  printf '=====> %s\n' "$1"
+}
+
+warn() {
+  printf ' !     %s\n' "$1" >&2
+}
+
+DRY_RUN=false
+APP=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dry-run)
+      DRY_RUN=true
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    --)
+      shift
+      APP="${1:-}"
+      break
+      ;;
+    -* )
+      warn "unknown option: $1"
+      usage
+      exit 1
+      ;;
+    * )
+      APP="$1"
+      shift
+      ;;
+  esac
+done
+
+if [[ -z "$APP" ]]; then
+  warn "app name required"
+  usage
+  exit 1
+fi
+
+DOCKER_BIN=${DOCKER_BIN:-$(command -v docker || true)}
+if [[ -z "$DOCKER_BIN" ]]; then
+  warn "docker binary not found"
+  exit 1
+fi
+
+DOKKU_ROOT=${DOKKU_ROOT:-/home/dokku}
+LOCK_FILE="$DOKKU_ROOT/$APP/.deploy.lock"
+CANCELLED=0
+
+kill_pids_matching() {
+  local pattern="$1"
+  local label="$2"
+  mapfile -t pids < <(pgrep -f "$pattern" 2>/dev/null || true)
+  if [[ ${#pids[@]} -eq 0 ]]; then
+    return
+  fi
+  CANCELLED=1
+  for pid in "${pids[@]}"; do
+    if $DRY_RUN; then
+      log "would terminate $label process pid=$pid"
+    else
+      log "terminating $label process pid=$pid"
+      kill "$pid" 2>/dev/null || true
+    fi
+  done
+  if ! $DRY_RUN; then
+    sleep 1
+    for pid in "${pids[@]}"; do
+      kill -0 "$pid" 2>/dev/null || continue
+      log "force killing $label process pid=$pid"
+      kill -9 "$pid" 2>/dev/null || true
+    done
+  fi
+}
+
+stop_containers_matching() {
+  local description="$1"
+  shift
+  local filters=("$@")
+  mapfile -t containers < <($DOCKER_BIN ps "${filters[@]}" --format '{{.ID}} {{.Command}}' 2>/dev/null || true)
+  local matched=()
+  for entry in "${containers[@]}"; do
+    local id=${entry%% *}
+    local cmd=${entry#* }
+    if [[ "$cmd" != *"build"* && "$cmd" != *"/build"* && "$cmd" != *"pack"* ]]; then
+      continue
+    fi
+    matched+=("$id::$cmd")
+  done
+  if [[ ${#matched[@]} -eq 0 ]]; then
+    return
+  fi
+  CANCELLED=1
+  for entry in "${matched[@]}"; do
+    local id=${entry%%::*}
+    local cmd=${entry#*::}
+    if $DRY_RUN; then
+      log "would remove $description container $id (cmd: $cmd)"
+    else
+      log "removing $description container $id (cmd: $cmd)"
+      $DOCKER_BIN rm -f "$id" >/dev/null 2>&1 || $DOCKER_BIN kill "$id" >/dev/null 2>&1 || true
+    fi
+  done
+}
+
+# Kill docker build processes for the app image
+APP_IMAGE="dokku/${APP}:latest"
+kill_pids_matching "$DOCKER_BIN[[:space:]]+image[[:space:]]+build.*$APP_IMAGE" "docker build"
+
+# Kill pack (cloud native buildpacks) builds
+kill_pids_matching "pack[[:space:]]+build[[:space:]]+$APP_IMAGE" "pack build"
+
+# Kill pack builds invoked via app name without registry prefix
+kill_pids_matching "pack[[:space:]]+build[[:space:]].*${APP}" "pack build"
+
+# Kill docker container based build steps (herokuish/buildpacks)
+stop_containers_matching "build phase" --filter "label=com.dokku.app-name=${APP}" --filter "status=running"
+
+# Clean up deploy lock if present
+if [[ -f "$LOCK_FILE" ]]; then
+  CANCELLED=1
+  if $DRY_RUN; then
+    log "would remove deploy lock $LOCK_FILE"
+  else
+    log "removing deploy lock $LOCK_FILE"
+    rm -f "$LOCK_FILE"
+  fi
+fi
+
+if [[ $CANCELLED -eq 0 ]]; then
+  log "no running builds detected for ${APP}"
+else
+  if $DRY_RUN; then
+    log "dry run complete (no changes made)"
+  else
+    log "cancelled build activity for ${APP}"
+  fi
+fi


### PR DESCRIPTION
## Summary
- add a reusable remote script that terminates docker/pack builders and clears deploy locks for a Dokku app
- wrap it with a client shell that streams the remote logic over ssh (with host/port detection) so it can be invoked locally now
- add docs explaining how to run it and hinting at future plugin packaging

## Testing
- scripts/dokku-cancel-build/cancel-builds --local --dry-run demo-app
